### PR TITLE
Fixes from ocp

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,11 +34,7 @@ parts:
   ops-utils:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-utils
     after: [ openvswitch ]
 
@@ -46,7 +42,9 @@ parts:
     plugin: cmake
     source: https://github.com/lool/googletest.git
     source-type: git
-    configflags: [ "-DBUILD_SHARED_LIBS=ON" ]
+    configflags: 
+      - "-DBUILD_SHARED_LIBS=ON"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
 
   i2c-header-hack:
     plugin: copy
@@ -63,6 +61,8 @@ parts:
         #   sudo ln -s /usr/include/linux/i2c-dev.h /usr/include/linux/i2c-dev-user.h
         # fi
       - libyaml-cpp0.3-dev
+    configflags:
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
 
   ops-cli:
     plugin: autotools
@@ -74,6 +74,8 @@ parts:
       - "--enable-ovsdb"
       - "--enable-vtysh"
       - "--enable-shared"
+      - "--prefix=/usr"
+      - "--disable-static"
     source: openswitch/src/ops-cli
     after: [ openvswitch ]
     build-packages: [ libreadline-dev, pkg-config ]
@@ -85,11 +87,7 @@ parts:
   ops-arpmgrd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-arpmgrd
     after: [ openvswitch ]
 
@@ -100,44 +98,28 @@ parts:
   ops-fand:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-fand
     after: [ openvswitch, ops-cli, ops-config-yaml ]
 
   ops-intfd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-intfd
     after: [ openvswitch, ops-config-yaml, ops-utils ]
 
   ops-ledd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-ledd
     after: [ openvswitch, ops-cli, ops-config-yaml ]
 
   ops-pmd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-pmd
     after: [ openvswitch, ops-config-yaml ]
 
@@ -149,22 +131,14 @@ parts:
   ops-powerd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-powerd
     after: [ openvswitch, ops-cli, ops-config-yaml, systemd-pc-hack ]
 
   ops-portd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-portd
     after: [ openvswitch ]
 
@@ -180,22 +154,14 @@ parts:
 #  ops-switchd-opennsl-plugin:
 #    plugin: cmake
 #    configflags:
-#      - "-DCMAKE_C_FLAGS=-DOPS"
-#      - "-DCMAKE_CXX_FLAGS=-DOPS"
-#      - "-DCMAKE_BUILD_TYPE=Debug"
-#      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-#      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+#      - "-DCMAKE_INSTALL_PREFIX=/usr"
 #    source: openswitch/src/ops-switchd-opennsl-plugin
 #    after: [ openvswitch ]
 
   ops-sysd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     build-packages:
       - zlib1g-dev
     source: openswitch/src/ops-sysd
@@ -204,22 +170,14 @@ parts:
   ops-tempd:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-tempd
     after: [ openvswitch, ops-cli, ops-config-yaml ]
 
   ops-vland:
     plugin: cmake
     configflags:
-      - "-DCMAKE_C_FLAGS=-DOPS"
-      - "-DCMAKE_CXX_FLAGS=-DOPS"
-      - "-DCMAKE_BUILD_TYPE=Debug"
-      - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
-      - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
+      - "-DCMAKE_INSTALL_PREFIX=/usr"
     source: openswitch/src/ops-vland
     after: [ openvswitch ]
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -141,6 +141,11 @@ parts:
     source: openswitch/src/ops-pmd
     after: [ openvswitch, ops-config-yaml ]
 
+  systemd-pc-hack:
+    plugin: copy
+    files:
+      systemd.pc: usr/lib/pkgconfig/systemd.pc
+
   ops-powerd:
     plugin: cmake
     configflags:
@@ -150,7 +155,7 @@ parts:
       - "-DCMAKE_C_FLAGS_DEBUG=-DO0"
       - "-DCMAKE_CXX_FLAGS_DEBUG=-DO0"
     source: openswitch/src/ops-powerd
-    after: [ openvswitch, ops-cli, ops-config-yaml ]
+    after: [ openvswitch, ops-cli, ops-config-yaml, systemd-pc-hack ]
 
   ops-portd:
     plugin: cmake

--- a/systemd.pc
+++ b/systemd.pc
@@ -1,0 +1,35 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+prefix=/usr
+libdir=/usr/lib/x86_64-linux-gnu
+systemdutildir=/lib/systemd
+systemdsystemunitdir=/lib/systemd/system
+systemdsystempresetdir=/lib/systemd/system-preset
+systemduserunitdir=/usr/lib/systemd/user
+systemduserpresetdir=/usr/lib/systemd/user-preset
+systemdsystemconfdir=/etc/systemd/system
+systemduserconfdir=/etc/systemd/user
+systemdsystemunitpath=${systemdsystemconfdir}:/etc/systemd/system:/run/systemd/system:/usr/local/lib/systemd/system:${systemdsystemunitdir}:/usr/lib/systemd/system:/lib/systemd/system
+systemduserunitpath=${systemduserconfdir}:/etc/systemd/user:/run/systemd/user:/usr/local/lib/systemd/user:/usr/local/share/systemd/user:${systemduserunitdir}:/usr/lib/systemd/user:/usr/share/systemd/user
+systemdsystemgeneratordir=/lib/systemd/system-generators
+systemdusergeneratordir=/usr/lib/systemd/user-generators
+systemdsleepdir=/lib/systemd/system-sleep
+systemdshutdowndir=/lib/systemd/system-shutdown
+tmpfilesdir=/usr/lib/tmpfiles.d
+sysusersdir=/usr/lib/sysusers.d
+sysctldir=/usr/lib/sysctl.d
+binfmtdir=/usr/lib/binfmt.d
+modulesloaddir=/usr/lib/modules-load.d
+catalogdir=/usr/lib/systemd/catalog
+systemuidmax=999
+systemgidmax=999
+
+Name: systemd
+Description: systemd System and Service Manager
+URL: http://www.freedesktop.org/wiki/Software/systemd
+Version: 219


### PR DESCRIPTION
Hi there,

these are the remaining changes I had locally from OCP; the build needs some snapcraft changes/workarounds too.

I'd suggest we set BUILD_SHARED_LIBS=yes on all cmake builds to disabled static libraries.

Cheers,
- Loïc
