### PR TITLE
Fix for dependencies

### DIFF
--- a/setup_snappy
+++ b/setup_snappy
@@ -16,7 +16,7 @@ fi
 
 # Dependencies for setup
 
-sudo apt-get -y install python2.7 libi2c-dev libgtest-dev cmake build-essential git 
+sudo apt-get -y install python2.7 libi2c-dev libgtest-dev cmake build-essential git squashfs-tools
 
 # Get the Openswitch src
 if [ ! -d $OPS ] ; then

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,10 +56,7 @@ parts:
     plugin: cmake
     source: openswitch/src/ops-config-yaml
     after: [ gtest, i2c-header-hack ]
-    build-packages:
-        # if [ ! -e /usr/include/linux/i2c-dev-user.h ] ; then
-        #   sudo ln -s /usr/include/linux/i2c-dev.h /usr/include/linux/i2c-dev-user.h
-        # fi
+    stage-packages:
       - libyaml-cpp0.3-dev
     configflags:
       - "-DCMAKE_INSTALL_PREFIX=/usr"
@@ -162,7 +159,7 @@ parts:
     plugin: cmake
     configflags:
       - "-DCMAKE_INSTALL_PREFIX=/usr"
-    build-packages:
+    stage-packages:
       - zlib1g-dev
     source: openswitch/src/ops-sysd
     after: [ openvswitch, ops-config-yaml, ops-utils ]


### PR DESCRIPTION
Hi,

These commits fix:
- A missing dependency in the setup script: squashfs-tools
- zlib and libyaml-cpp are actually stage packages instead of build packages for ops-config-yaml and ops-sysd parts.

JD
